### PR TITLE
Update pillar/grain master cache logic

### DIFF
--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -189,16 +189,16 @@ class MasterPillarUtil(object):
             cret = dict([(minion_id, mcache) for (minion_id, mcache) in six.iteritems(cached_grains) if mcache])
             missed_minions = [minion_id for minion_id in minion_ids if minion_id not in cret]
             log.debug('Missed cached minion grains for: %s', missed_minions)
-            if self.grains_fallback:
+            if self.grains_fallback and len(missed_minions) > 0:
                 lret = self._get_live_minion_grains(missed_minions)
-            ret = dict(list(six.iteritems(dict([(minion_id, {}) for minion_id in minion_ids]))) + list(lret.items()) + list(cret.items()))
+            ret = dict(list(six.iteritems(dict([(minion_id, {}) for minion_id in minion_ids]))) + list(cret.items()) + list(lret.items()))
         else:
             lret = self._get_live_minion_grains(minion_ids)
             missed_minions = [minion_id for minion_id in minion_ids if minion_id not in lret]
             log.debug('Missed live minion grains for: %s', missed_minions)
-            if self.grains_fallback:
+            if self.grains_fallback and len(missed_minions) > 0:
                 cret = dict([(minion_id, mcache) for (minion_id, mcache) in six.iteritems(cached_grains) if mcache])
-            ret = dict(list(six.iteritems(dict([(minion_id, {}) for minion_id in minion_ids]))) + list(lret.items()) + list(cret.items()))
+            ret = dict(list(six.iteritems(dict([(minion_id, {}) for minion_id in minion_ids]))) + list(cret.items()) + list(lret.items()))
         return ret
 
     def _get_minion_pillar(self, *minion_ids, **kwargs):
@@ -214,16 +214,16 @@ class MasterPillarUtil(object):
             cret = dict([(minion_id, mcache) for (minion_id, mcache) in six.iteritems(cached_pillar) if mcache])
             missed_minions = [minion_id for minion_id in minion_ids if minion_id not in cret]
             log.debug('Missed cached minion pillars for: %s', missed_minions)
-            if self.pillar_fallback:
+            if self.pillar_fallback and len(missed_minions) > 0:
                 lret = dict([(minion_id, self._get_live_minion_pillar(minion_id, grains.get(minion_id, {}))) for minion_id in missed_minions])
-            ret = dict(list(six.iteritems(dict([(minion_id, {}) for minion_id in minion_ids]))) + list(lret.items()) + list(cret.items()))
+            ret = dict(list(six.iteritems(dict([(minion_id, {}) for minion_id in minion_ids]))) + list(cret.items()) + list(lret.items()))
         else:
             lret = dict([(minion_id, self._get_live_minion_pillar(minion_id, grains.get(minion_id, {}))) for minion_id in minion_ids])
             missed_minions = [minion_id for minion_id in minion_ids if minion_id not in lret]
             log.debug('Missed live minion pillars for: %s', missed_minions)
-            if self.pillar_fallback:
+            if self.pillar_fallback and len(missed_minions) > 0:
                 cret = dict([(minion_id, mcache) for (minion_id, mcache) in six.iteritems(cached_pillar) if mcache])
-            ret = dict(list(six.iteritems(dict([(minion_id, {}) for minion_id in minion_ids]))) + list(lret.items()) + list(cret.items()))
+            ret = dict(list(six.iteritems(dict([(minion_id, {}) for minion_id in minion_ids]))) + list(cret.items()) + list(lret.items()))
         return ret
 
     def _tgt_to_list(self):


### PR DESCRIPTION
### What does this PR do?

When executing _get_minion_grains and all nodes are loaded via cache, len(missed_minions) == 0.
This causes  ```lret = self._get_live_minion_grains(missed_minions)```  to execute with an empty list which results in the print statement ```No minions matched the target. No command was sent, no jid was assigned.``` but everything else executes fine...
This adds additional validation before executing the fallback statements.

This also ensures that directly queried minion grains/pillars "lret" overwrites any cached data "cret" before return.

### What issues does this PR fix or reference?
No issue number.

### Tests written?

No

### Commits signed with GPG?

Yes
